### PR TITLE
CONFIG: Update NuGet dependencies and modernise ADotNet build/PR workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "CONFIG"
+    labels:
+      - "dependencies"
+    ignore:
+        - dependency-name: "FluentAssertions"
+          versions: ["8.x", "9.x", "10.x", "*"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ on:
     - synchronize
     - reopened
     - closed
-    branches:
-    - main
 jobs:
   build:
     name: Build
@@ -19,9 +17,9 @@ jobs:
     - name: Enable long paths for Git
       run: git config --global core.longpaths true
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Setup .Net
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.100
     - name: Restore
@@ -47,7 +45,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'RELEASES')
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
       with:
         token: ${{ secrets.PAT_FOR_TAGGING }}
     - name: Configure Git
@@ -120,9 +118,9 @@ jobs:
     if: needs.add_tag.result == 'success'
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Setup .Net
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.0.100
     - name: Restore

--- a/.github/workflows/prLinter.yml
+++ b/.github/workflows/prLinter.yml
@@ -11,11 +11,12 @@ on:
     - main
 jobs:
   label:
-    name: Add Label(s)
+    name: Label
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
     - name: Apply Label
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: >-
@@ -84,16 +85,17 @@ jobs:
           }
     permissions:
       contents: read
+      issues: write
       pull-requests: write
   requireIssueOrTask:
     name: Require Issue Or Task Association
     runs-on: ubuntu-latest
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Get PR Information
       id: get_pr_info
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         script: >2-
               const pr = await github.rest.pulls.get({
@@ -110,7 +112,7 @@ jobs:
               console.log(`PR Body: ${prBody}`);
     - name: Check For Associated Issues Or Tasks
       id: check_for_issues_or_tasks
-      if: ${{ steps.get_pr_info.outputs.prOwner != 'dependabot[bot]' }}
+      if: ${{ !contains(',dependabot[bot],', format(',{0},', steps.get_pr_info.outputs.prOwner)) }}
       env:
         PR_BODY: ${{ steps.get_pr_info.outputs.description }}
       run: >2-
@@ -131,3 +133,42 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+  setAuthorAsPrAssignee:
+    name: Set Author As PR Assignee
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+    - name: Set Author As PR Assignee
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: >
+          const pr = context.payload.pull_request;
+
+          if (!pr) {
+            console.log('No pull request context available.');
+            return;
+          }
+
+
+          const author = pr.user.login;
+
+          if (author.endsWith('[bot]')) {
+            console.log(`Skipping bot author: ${author}`);
+            return;
+          }
+
+
+          console.log(`Assigning PR to author: ${author}`);
+
+
+          await github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+            assignees: [author]
+          });
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write

--- a/ISL.Security.Client.Infrastructure/ISL.Security.Client.Infrastructure.csproj
+++ b/ISL.Security.Client.Infrastructure/ISL.Security.Client.Infrastructure.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ADotNet" Version="4.3.0" />
+		<PackageReference Include="ADotNet" Version="5.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/ISL.Security.Client.Infrastructure/Services/ScriptGenerationService.cs
+++ b/ISL.Security.Client.Infrastructure/Services/ScriptGenerationService.cs
@@ -7,7 +7,7 @@ using System.IO;
 using ADotNet.Clients;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets;
 using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks;
-using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV4s;
+using ADotNet.Models.Pipelines.GithubPipelines.DotNets.Tasks.SetupDotNetTaskV5s;
 
 namespace ISL.Security.Client.Infrastructure.Services
 {
@@ -30,8 +30,7 @@ namespace ISL.Security.Client.Infrastructure.Services
 
                     PullRequest = new PullRequestEvent
                     {
-                        Types = ["opened", "synchronize", "reopened", "closed"],
-                        Branches = [branchName]
+                        Types = ["opened", "synchronize", "reopened", "closed"]
                     }
                 },
 
@@ -52,16 +51,16 @@ namespace ISL.Security.Client.Infrastructure.Services
                                     Run = "git config --global core.longpaths true"
                                 },
 
-                                new CheckoutTaskV4
+                                new CheckoutTaskV5
                                 {
                                     Name = "Check out"
                                 },
 
-                                new SetupDotNetTaskV4
+                                new SetupDotNetTaskV5
                                 {
                                     Name = "Setup .Net",
 
-                                    With = new TargetDotNetVersionV4
+                                    With = new TargetDotNetVersionV5
                                     {
                                         DotNetVersion = dotNetVersion
                                     }
@@ -86,7 +85,7 @@ namespace ISL.Security.Client.Infrastructure.Services
                     },
                     {
                         "add_tag",
-                        new TagJob(
+                        new TagJobV2(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "build",
                             projectRelativePath: $"{projectName}/{projectName}.csproj",
@@ -98,7 +97,7 @@ namespace ISL.Security.Client.Infrastructure.Services
                     },
                     {
                         "publish",
-                        new PublishJobV3(
+                        new PublishJobV4(
                             runsOn: BuildMachines.UbuntuLatest,
                             dependsOn: "add_tag",
                             dotNetVersion: dotNetVersion,
@@ -142,16 +141,23 @@ namespace ISL.Security.Client.Infrastructure.Services
                 {
                     {
                         "label",
-                        new LabelJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        new LabelJobV3(runsOn: BuildMachines.UbuntuLatest)
                         {
-                            Name = "Add Label(s)",
+                            Name = "Label"
                         }
                     },
                     {
                         "requireIssueOrTask",
-                        new RequireIssueOrTaskJob()
+                        new RequireIssueOrTaskJobV2(excludedAuthors: "dependabot[bot]")
                         {
                             Name = "Require Issue Or Task Association",
+                        }
+                    },
+                    {
+                        "setAuthorAsPrAssignee",
+                        new SetAuthorAsPrAssigneeJobV2(runsOn: BuildMachines.UbuntuLatest)
+                        {
+                            Name = "Set Author As PR Assignee",
                         }
                     },
                 }

--- a/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
+++ b/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />

--- a/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
+++ b/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
@@ -22,7 +22,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
+++ b/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
+++ b/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
@@ -19,7 +19,7 @@
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />

--- a/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
+++ b/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
@@ -20,7 +20,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />

--- a/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
+++ b/ISL.Security.Client.Tests.Acceptance/ISL.Security.Client.Tests.Acceptance.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />

--- a/ISL.Security.Client.Tests.Unit/ISL.Security.Client.Tests.Unit.csproj
+++ b/ISL.Security.Client.Tests.Unit/ISL.Security.Client.Tests.Unit.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="FluentAssertions" Version="[7.2.2]" />
 		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ISL.Security.Client/ISL.Security.Client.csproj
+++ b/ISL.Security.Client/ISL.Security.Client.csproj
@@ -49,7 +49,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Xeption" Version="2.9.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />

--- a/ISL.Security.Client/ISL.Security.Client.csproj
+++ b/ISL.Security.Client/ISL.Security.Client.csproj
@@ -52,7 +52,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 

--- a/ISL.Security.Client/ISL.Security.Client.csproj
+++ b/ISL.Security.Client/ISL.Security.Client.csproj
@@ -51,7 +51,7 @@
 		<PackageReference Include="Xeption" Version="2.9.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>

--- a/ISL.Security.Client/ISL.Security.Client.csproj
+++ b/ISL.Security.Client/ISL.Security.Client.csproj
@@ -50,7 +50,7 @@
 	<ItemGroup>
 		<PackageReference Include="Xeption" Version="2.9.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />

--- a/ISL.Security.Client/ISL.Security.Client.csproj
+++ b/ISL.Security.Client/ISL.Security.Client.csproj
@@ -53,7 +53,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
Brings ISL.Security.Client up to the .NET 10 modernisation standard (rebuilt cleanly on top of current main v6.0.0.0).

closes [AB#29744](https://dev.azure.com/NELAnalytics/aef6c175-110f-4ba4-82fc-70761f459236/_workitems/edit/29744)

### Dependency updates (CONFIG)
- Microsoft.Extensions.Configuration / .Json / .Binder / .EnvironmentVariables / .DependencyInjection 10.0.8 -> 10.0.9
- Microsoft.NET.Test.Sdk 18.6.0 -> 18.7.0
- ADotNet 4.3.0 -> 5.0.0

### Workflow modernisation (CODE RUB)
- ADotNet components -> latest (CheckoutTaskV5 / SetupDotNetTaskV5 / LabelJobV3 / TagJobV2 / PublishJobV4); build.yml on Node-24 actions, SDK 10.0.100 (main was on V4 components)
- prLinter.yml: added Set Author As PR Assignee; RequireIssueOrTask -> V2 (excludes dependabot[bot]); Label -> V3 (byte-identical to reference)
- Dropped the PR branch-filter from build.yml (kept on prLinter, per Christo)
- Added dependabot.yml (was missing) with CONFIG prefix + FluentAssertions ignore

### Validation
- Build: 0 errors, 0 obsolete warnings, 0 vulnerable packages
- Tests: 258 pass (21 Acceptance + 237 Unit)
- Workflows regenerated from the Infrastructure project (idempotent, not hand-edited)
